### PR TITLE
Fix AC mode selection via HA

### DIFF
--- a/components/ac_hi/ac_hi.cpp
+++ b/components/ac_hi/ac_hi.cpp
@@ -314,6 +314,7 @@ void ACHIComponent::on_switch(ControlType t, bool state) {
   switch (t) {
     case CTRL_POWER:
       this->power_bin_ = state ? 0b00001100 : 0b00000100;
+      if (!state) this->mode_bin_ = 0x00;  // clear mode when turning off
       this->lock_update_ = true;
       this->schedule_write_();
       break;
@@ -373,7 +374,7 @@ void ACHIComponent::on_select(ControlType t, const std::string &value) {
     else if (value == "cool") idx = 2;
     else if (value == "dry") idx = 3;
     else if (value == "auto") idx = 4;
-    uint8_t mode = ((idx << 1) | 0x01) << 4;
+    uint8_t mode = idx << 4;
     this->mode_bin_ = mode;
     this->lock_update_ = true;
     this->schedule_write_();

--- a/components/ac_hi/ac_hi.h
+++ b/components/ac_hi/ac_hi.h
@@ -151,7 +151,7 @@ class ACHIComponent : public PollingComponent, public uart::UARTDevice {
 
   // pending bit fields
   uint8_t power_bin_{0};
-  uint8_t mode_bin_{0};
+  uint8_t mode_bin_{0};             // idx<<4 — код режима
   uint8_t updown_bin_{0};
   uint8_t leftright_bin_{0};
   uint8_t turbo_bin_{0};

--- a/components/ac_hi/climate/ac_hi_climate.cpp
+++ b/components/ac_hi/climate/ac_hi_climate.cpp
@@ -100,6 +100,7 @@ void ACHiClimate::control(const climate::ClimateCall &call) {
     auto m = *call.get_mode();
     if (m == climate::CLIMATE_MODE_OFF) {
       power_bin_ = 0b00000100; // keep bit2, clear bit3
+      mode_bin_ = 0x00;        // clear mode when powering off
       this->mode = climate::CLIMATE_MODE_OFF;
       this->power_ = false;
     } else {
@@ -107,15 +108,15 @@ void ACHiClimate::control(const climate::ClimateCall &call) {
       this->mode = m;
       this->power_ = true;
 
-      // индексы: 0=FAN_ONLY,1=HEAT,2=COOL,3=DRY,4=AUTO → odd-nibble при записи
+      // индексы: 0=FAN_ONLY,1=HEAT,2=COOL,3=DRY,4=AUTO
       uint8_t idx = 4; // auto
       if (m == climate::CLIMATE_MODE_HEAT) idx = 1;
       else if (m == climate::CLIMATE_MODE_COOL) idx = 2;
       else if (m == climate::CLIMATE_MODE_DRY)  idx = 3;
       else if (m == climate::CLIMATE_MODE_FAN_ONLY) idx = 0;
 
-      // код в старшем полубайте = ((idx<<1)|1)
-      mode_bin_ = uint8_t((((idx << 1) | 0x01) << 4));
+      // код в старшем полубайте = idx<<4
+      mode_bin_ = uint8_t(idx << 4);
     }
     need_write = true;
   }

--- a/components/ac_hi/climate/ac_hi_climate.h
+++ b/components/ac_hi/climate/ac_hi_climate.h
@@ -62,7 +62,7 @@ class ACHiClimate : public climate::Climate, public Component, public uart::UART
 
   // write-intent (по рабочему legacy yaml)
   uint8_t power_bin_{0x04};                 // база 0x04; ON добавляет bit3
-  uint8_t mode_bin_{0x10};                  // ((idx<<1)|1)<<4  — odd-nibble схема
+  uint8_t mode_bin_{0x40};                  // idx<<4 — код режима в старшем полубайте
   uint8_t wind_code_{0x01};                 // 1=auto; 12/14/16=low/med/high
   uint8_t temp_byte_{(24u << 1) | 1u};      // ((°C)<<1)|1
   uint8_t updown_bin_{0x10};                // 0x30 on, 0x10 off -> [32]


### PR DESCRIPTION
## Summary
- fix encoding of mode field when writing to AC so Home Assistant changes persist
- reset mode bits when powering off

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f6d6efec4832dad0d7a7c5b7ed4f3